### PR TITLE
Фикс тряпок киборгов

### DIFF
--- a/modular_skyrat/modules/borgs/code/robot_upgrade.dm
+++ b/modular_skyrat/modules/borgs/code/robot_upgrade.dm
@@ -18,6 +18,7 @@
 						/obj/item/cautery/advanced,
 						/obj/item/blood_filter/advanced,
 						/obj/item/healthanalyzer/advanced,
+						/obj/item/surgical_drapes, //BLUEMOON ADD т.к. изначально тряпок у боргов нет, а омнитулы с ними удаляются
 						)
 	items_to_remove = list(
 						/obj/item/borg/cyborg_omnitool/medical,


### PR DESCRIPTION
## About The Pull Request

Улучшение на инструменты борга убирает омнируку, в которой были изначально тряпки, но не добавляет взамен новым хирургическим инструментам саму тряпку. Этот фикс исправляет недочёт.

## Proof Of Testing

![image](https://github.com/user-attachments/assets/a945e498-c0ed-4407-a4da-03d6fd86f28c)

## Changelog

Улучшение "medical cyborg advanced surgery tools" теперь также добавляет тряпки для операции