### PR TITLE
add nunchaku to traitor uplink

### DIFF
--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -52,15 +52,6 @@
 	cost = 6
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 
-/datum/uplink_item/dangerous/nunchaku
-	name = "Syndie Fitness Nunchuks"
-	desc = "Heavyweight titanium nunchucks that can be used to knock out and harm your opponent quickly and easily.\
-		In close combat, it allows you to block all melee attacks and throws, punishing the offender."
-	item = /obj/item/melee/baton/nunchaku
-	cost = 7
-	purchasable_from = ~UPLINK_SPY //spy get their own tg version
-	uplink_item_flags = SYNDIE_TRIPS_CONTRABAND
-
 /datum/uplink_item/dangerous/rapid
 	name = "Gloves of the North Star"
 	desc = "These gloves let the user punch people very fast. Does not improve weapon attack speed or the meaty fists of a hulk."

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -52,6 +52,15 @@
 	cost = 6
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 
+/datum/uplink_item/dangerous/nunchaku
+	name = "Syndie Fitness Nunchuks"
+	desc = "Heavyweight titanium nunchucks that can be used to knock out and harm your opponent quickly and easily.\
+		In close combat, it allows you to block all melee attacks and throws, punishing the offender."
+	item = /obj/item/melee/baton/nunchaku
+	cost = 7
+	purchasable_from = ~UPLINK_SPY //spy get their own tg version
+	uplink_item_flags = SYNDIE_ILLEGAL_TECH | SYNDIE_TRIPS_CONTRABAND
+
 /datum/uplink_item/dangerous/rapid
 	name = "Gloves of the North Star"
 	desc = "These gloves let the user punch people very fast. Does not improve weapon attack speed or the meaty fists of a hulk."

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -59,7 +59,7 @@
 	item = /obj/item/melee/baton/nunchaku
 	cost = 7
 	purchasable_from = ~UPLINK_SPY //spy get their own tg version
-	uplink_item_flags = SYNDIE_ILLEGAL_TECH | SYNDIE_TRIPS_CONTRABAND
+	uplink_item_flags = SYNDIE_TRIPS_CONTRABAND
 
 /datum/uplink_item/dangerous/rapid
 	name = "Gloves of the North Star"

--- a/modular_zzplurt/code/modules/uplink/uplink_items/dangerous.dm
+++ b/modular_zzplurt/code/modules/uplink/uplink_items/dangerous.dm
@@ -1,0 +1,8 @@
+/datum/uplink_item/dangerous/nunchaku
+	name = "Syndie Fitness Nunchuks"
+	desc = "Heavyweight titanium nunchucks that can be used to knock out and harm your opponent quickly and easily.\
+		In close combat, it allows you to block all melee attacks and throws, punishing the offender."
+	item = /obj/item/melee/baton/nunchaku
+	cost = 7
+	purchasable_from = ~UPLINK_SPY //spy get their own tg version
+	uplink_item_flags = SYNDIE_TRIPS_CONTRABAND

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10191,6 +10191,7 @@
 #include "modular_zzplurt\code\modules\thirst\mob_mood.dm"
 #include "modular_zzplurt\code\modules\thirst\reagents.dm"
 #include "modular_zzplurt\code\modules\thirst\screen_hud.dm"
+#include "modular_zzplurt\code\modules\uplink\uplink_items\dangerous.dm"
 #include "modular_zzplurt\code\modules\vending\autodrobe.dm"
 #include "modular_zzplurt\code\modules\vending\boozeomat.dm"
 #include "modular_zzplurt\code\modules\vending\clothmate.dm"


### PR DESCRIPTION
## About The Pull Request

Добавляет самые обычные фитнес нунчаки в аплинк тритора (7 TC)

## Why It's Good For The Game

На ТГ нунчаки только у шпиона, на нове/фф/вайтмуне будут и у триторов, ввиду редкости выпадания роли шпионов.

## Changelog

:cl:
add: Добавлен хороший фитнес инвентарь в категорию dangerous аплинка предателя (7 TC)
/:cl:

