### PR TITLE
Bloodfledge for Hemophage rebalance

### DIFF
--- a/modular_zzplurt/code/datums/quirks/positive_quirks/bloodfledge.dm
+++ b/modular_zzplurt/code/datums/quirks/positive_quirks/bloodfledge.dm
@@ -1399,7 +1399,7 @@
 
 	// Condition: Insufficient blood volume
 	else
-		if(action_owner.blood_volume < BLOOD_VOLUME_SURVIVE) // WHITEMOON FIX: Был неверно поставлен знак (> вместо <), из-за чего выводило сообщение о недостатке крови при её наличии в большом количестве.
+		if(action_owner.blood_volume < BLOOD_VOLUME_NORMAL) // WHITEMOON EDIT: Требование к использованию способности повышено с 20% до 100% крови и выше
 			revive_failed += "\n- You don't have enough blood volume left!"
 
 	// Condition: Damage limit, brute
@@ -1520,7 +1520,7 @@
 	// Blood volume mode
 	else
 		// Set dangerously low blood
-		action_owner.blood_volume = min(action_owner.blood_volume, BLOOD_VOLUME_SURVIVE)
+		action_owner.blood_volume = min(action_owner.blood_volume, BLOOD_VOLUME_SAFE) //WHITEMOON EDIT: Значение повышено с Survive до Safe, т.к. в противном случае после использования способности гемофаги умирают мгновенно
 
 	// Apply dizzy effect
 	action_owner.adjust_dizzy_up_to(20 SECONDS, 60 SECONDS)


### PR DESCRIPTION
## About The Pull Request

Изменяет требование квирка (ну и в целом делает квирк юзабельным) Bloodfledge для гемофагов.
Было повышено требование к наличию крови для использования способности восстановления с 20% до 100% и выше (т.е. минимум 560мл крови)
Теперь после использования восстановления гемофаги не умирают мгновенно. Уровень крови снизится до 85% после прожатия абилки во избежании повторного использования способности сразу.

## Why It's Good For The Game

Чинит перк, который для гемофагов работал некорректно.