### PR TITLE
Формальдегид для МедиБоргов

### DIFF
--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -7,6 +7,7 @@
 		/datum/reagent/medicine/c2/multiver,\
 		/datum/reagent/medicine/salglu_solution,\
 		/datum/reagent/medicine/spaceacillin,\
+		/datum/reagent/toxin/formaldehyde,\
 		/datum/reagent/medicine/lidocaine\
 	) //SKYRAT EDIT line 10 added Lidocaine
 #define EXPANDED_MEDICAL_REAGENTS list(\


### PR DESCRIPTION
Исправляем неприятную проблему отсутствия и невозможности самостоятельно получить формальдегид для Боргов с Медицинским Модулем.

Изменение по [Предложению](https://discord.com/channels/875735187449847830/1371343838798680125)
![7700ECA4-094B-4AF2-9E19-45E9AD4476CC](https://github.com/user-attachments/assets/3d2eab20-8159-4fee-89e2-4dfe346b9f5b)
![90D021FB-DE3C-4FD9-B045-4007EBDC65FA](https://github.com/user-attachments/assets/0197c8d8-0a59-470e-9841-e5e93a57d4ff)

