### PR TITLE
Возвращение обновления баунти шпионов до 12 минут

### DIFF
--- a/code/modules/antagonists/spy/spy_bounty_handler.dm
+++ b/code/modules/antagonists/spy/spy_bounty_handler.dm
@@ -5,7 +5,7 @@
  */
 /datum/spy_bounty_handler
 	/// Timer between when all bounties are refreshed.
-	var/refresh_time = 23 MINUTES //BUBBER EDIT: FROM 12 MINUTES TO 23 MINUTES
+	var/refresh_time = 12 MINUTES
 	/// timerID of the active refresh timer.
 	var/refresh_timer
 	/// Number of times we have refreshed bounties


### PR DESCRIPTION
Мелкий антагонист, который имеет возможность проявить всего раз в двадцать минут - плохая идея. Больше баунти побуждает больше действовать. Отмена изменений сплюртов